### PR TITLE
Feature/pdf parser

### DIFF
--- a/src/main/java/io/academic/entity/Article.java
+++ b/src/main/java/io/academic/entity/Article.java
@@ -51,6 +51,10 @@ public class Article extends AbstractAuditingEntity {
     @Type(type = "text")
     private String articleIdentifier;
 
+    @Column
+    @Type(type = "text")
+    private String relation;
+
     public String getTitle() {
         return title;
     }
@@ -131,4 +135,11 @@ public class Article extends AbstractAuditingEntity {
         this.articleIdentifier = articleIdentifier;
     }
 
+    public String getRelation() {
+        return relation;
+    }
+
+    public void setRelation(String relation) {
+        this.relation = relation;
+    }
 }

--- a/src/main/java/io/academic/entity/Article.java
+++ b/src/main/java/io/academic/entity/Article.java
@@ -122,4 +122,13 @@ public class Article extends AbstractAuditingEntity {
     public void setBase64(String base64) {
         this.base64 = base64;
     }
+
+    public String getArticleIdentifier() {
+        return articleIdentifier;
+    }
+
+    public void setArticleIdentifier(String articleIdentifier) {
+        this.articleIdentifier = articleIdentifier;
+    }
+
 }

--- a/src/main/java/io/academic/entity/Article.java
+++ b/src/main/java/io/academic/entity/Article.java
@@ -43,6 +43,14 @@ public class Article extends AbstractAuditingEntity {
     @Type(type = "text")
     private String type;
 
+    @Column
+    @Type(type = "text")
+    private String base64;
+
+    @Column
+    @Type(type = "text")
+    private String articleIdentifier;
+
     public String getTitle() {
         return title;
     }
@@ -105,5 +113,13 @@ public class Article extends AbstractAuditingEntity {
 
     public void setType(String type) {
         this.type = type;
+    }
+
+    public String getBase64() {
+        return base64;
+    }
+
+    public void setBase64(String base64) {
+        this.base64 = base64;
     }
 }

--- a/src/main/java/io/academic/entity/Article.java
+++ b/src/main/java/io/academic/entity/Article.java
@@ -11,6 +11,10 @@ import javax.persistence.Table;
 @Entity
 public class Article extends AbstractAuditingEntity {
 
+    public Article(){
+
+    }
+
     @Column
     @Type(type = "text")
     private String title;

--- a/src/main/java/io/academic/entity/OaiDataProvider.java
+++ b/src/main/java/io/academic/entity/OaiDataProvider.java
@@ -16,10 +16,16 @@ public class OaiDataProvider extends AbstractAuditingEntity {
 
     }
 
-    public OaiDataProvider(String name, String url, String identifier) {
+    public OaiDataProvider(String name, String url,String downloadUrl, String identifier) {
         this.name = name;
         this.url = url;
+        this.downloadUrl = downloadUrl;
         this.identifier = identifier;
+    }
+
+    public OaiDataProvider(String url,String downloadUrl) {
+        this.url = url;
+        this.downloadUrl = downloadUrl;
     }
 
     public OaiDataProvider(String url) {
@@ -31,6 +37,9 @@ public class OaiDataProvider extends AbstractAuditingEntity {
 
     @Column
     private String url;
+
+    @Column
+    private String downloadUrl;
 
     @Column
     private String identifier;
@@ -69,5 +78,12 @@ public class OaiDataProvider extends AbstractAuditingEntity {
         return this;
     }
 
+    public String getDownloadUrl() {
+        return downloadUrl;
+    }
+
+    public void setDownloadUrl(String downloadUrl) {
+        this.downloadUrl = downloadUrl;
+    }
 
 }

--- a/src/main/java/io/academic/service/OaiDataProviderService.java
+++ b/src/main/java/io/academic/service/OaiDataProviderService.java
@@ -77,7 +77,7 @@ public class OaiDataProviderService {
     public String addRule(String url)
     {
 //        String rule = "?metadataPrefix=oai_dc&verb=ListRecords";
-        String rule = "?from=2018-01-07&until=2018-01-08&metadataPrefix=oai_dc&verb=ListRecords";
+        String rule = "?from=2017-01-01&until=2017-01-02&metadataPrefix=oai_dc&verb=ListRecords";
         return url+rule;
     }
 

--- a/src/main/java/io/academic/service/OaiService.java
+++ b/src/main/java/io/academic/service/OaiService.java
@@ -147,9 +147,15 @@ public class OaiService {
             article.setPublisher(parts[4].split("::")[1]);
             article.setDate(parts[5].split("::")[1]);
             article.setType(parts[6].split("::")[1]);
+            if (parts.length>10)
+            {
+                String downlaodUrl = parts[10].split("::")[1];
+                article.setRelation(downlaodUrl);
+                article.setBase64(UrlPdftoBase64(downlaodUrl));
+            }
             article.setDc(parsedDc.getDc());
             article.setArticleIdentifier(parseIdentifier(oaiRecord.getIdentifier()));
-            article.setBase64(UrlPdftoBase64("http://dergipark.gov.tr/download/article-file/"+parseIdentifier(oaiRecord.getIdentifier())));
+
             articles.add(article);
 
             elasticSave(article);
@@ -179,6 +185,7 @@ public class OaiService {
     public String UrlPdftoBase64(String url) {
         URL oracle = null;
         String base64 = null;
+        System.out.println(url);
         try {
             oracle = new URL(url);
             URLConnection yc = oracle.openConnection();

--- a/src/main/java/io/academic/service/OaiService.java
+++ b/src/main/java/io/academic/service/OaiService.java
@@ -9,12 +9,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-//import eu.luminis.elastic.document.DocumentService;
-//import eu.luminis.elastic.document.IndexRequest;
-//import eu.luminis.elastic.document.UpdateRequest;
-//import eu.luminis.elastic.index.IndexService;
-//import eu.luminis.elastic.search.SearchService;
-//import eu.luminis.elastic.document.response.IndexResponse;
 import io.academic.dao.DcDao;
 import io.academic.entity.*;
 import org.apache.commons.io.IOUtils;
@@ -115,7 +109,7 @@ public class OaiService {
     }
 
     public void elasticSave(Article article) throws IOException {
-        System.out.println("inside elasticsave");
+//        System.out.println("inside elasticsave");
 
 //        IndexRequest request = new IndexRequest(INDEX, TYPE).setEntity(article);
 //        System.out.println("before article get Article Identifier");
@@ -124,7 +118,7 @@ public class OaiService {
 //            request.setId(String.valueOf(article.getId()));
 //            System.out.println("inside article getid");
         IndexRequest request = new IndexRequest(INDEX,TYPE);
-//        request.setPipeline("academic-pdf");
+        request.setPipeline("academic-pdf");
 //            System.out.println(new Gson().toJson(article));
             request.source(new Gson().toJson(article), XContentType.JSON);
 //        }
@@ -207,7 +201,7 @@ public class OaiService {
             else
             {
                 article.setRelation("not available");
-                article.setBase64("not available");
+                article.setBase64("bm90IGF2YWlsYWJsZQ==");
             }
             article.setDc(parsedDc.getDc());
             article.setArticleIdentifier(parseIdentifier(oaiRecord.getIdentifier()));
@@ -216,7 +210,7 @@ public class OaiService {
 //            System.out.println("article add oncesi article id : "+article.getId());
             articles.add(article);
 
-            System.out.println("elastic save oncesi article id : "+article.getId());
+//            System.out.println("elastic save oncesi article id : "+article.getId());
 //            System.out.println("elastic save oncesi article title : "+article.getTitle());
             try {
                 elasticSave(article);
@@ -248,7 +242,7 @@ public class OaiService {
 
     public String UrlPdftoBase64(String url) {
         URL oracle = null;
-        String base64 = null;
+        String base64 = "bm90IGF2YWlsYWJsZQ=="; //means not available
         System.out.println(url);
         try {
             oracle = new URL(url);

--- a/src/main/java/io/academic/service/OaiService.java
+++ b/src/main/java/io/academic/service/OaiService.java
@@ -90,18 +90,7 @@ public class OaiService {
     public static final String INDEX = "harvester";
     private static final String TYPE = "oai";
 
-//    private  DocumentService documentService = null;
-//    private  IndexService indexService = null;
-//    private  SearchService searchService = null;
-//    private IndexRequest request;
 
-//    @Autowired
-//    public OaiService(DocumentService documentService, IndexService indexService, SearchService searchService) {
-//        this.documentService = documentService;
-//        this.indexService = indexService;
-////        indexService.createIndex();
-//        this.searchService = searchService;
-//    }
     @Autowired
     public OaiService()
     {
@@ -109,48 +98,22 @@ public class OaiService {
     }
 
     public void elasticSave(Article article) throws IOException {
-//        System.out.println("inside elasticsave");
-
-//        IndexRequest request = new IndexRequest(INDEX, TYPE).setEntity(article);
-//        System.out.println("before article get Article Identifier");
-//        System.out.println(article.getArticleIdentifier());
-//        if (article.getArticleIdentifier() != null) {
-//            request.setId(String.valueOf(article.getId()));
-//            System.out.println("inside article getid");
         IndexRequest request = new IndexRequest(INDEX,TYPE);
         request.setPipeline("academic-pdf");
-//            System.out.println(new Gson().toJson(article));
-            request.source(new Gson().toJson(article), XContentType.JSON);
+        // before using this pipeline we have to add pipeline to the elasticsearch by following command
+//        PUT _ingest/pipeline/academic-pdf
+//        {
+//            "description": "parse pdfs and index into ES",
+//                "processors" :
+//                  [
+//                      { "attachment" : { "field": "pdf" } },
+//                      { "remove" : { "field": "pdf" } }
+//                  ]
 //        }
 
-
-
+            request.source(new Gson().toJson(article), XContentType.JSON);
             IndexResponse indexResponse = restClient.index(request);
 
-//        String index = indexResponse.getIndex();
-//        String type = indexResponse.getType();
-//        String id = indexResponse.getId();
-//        long version = indexResponse.getVersion();
-//        System.out.println(index+" ,"+type+", "+id+", "+version);
-//        if (indexResponse.getResult() == DocWriteResponse.Result.CREATED) {
-//
-//        } else if (indexResponse.getResult() == DocWriteResponse.Result.UPDATED) {
-//
-//        }
-//        ReplicationResponse.ShardInfo shardInfo = indexResponse.getShardInfo();
-//        if (shardInfo.getTotal() != shardInfo.getSuccessful()) {
-//
-//        }
-//        if (shardInfo.getFailed() > 0) {
-//            for (ReplicationResponse.ShardInfo.Failure failure : shardInfo.getFailures()) {
-//                String reason = failure.reason();
-//            }
-//        }
-
-
-
-
-//        return documentService.index(request);
     }
 
 
@@ -179,11 +142,9 @@ public class OaiService {
             oaiRecord.setState(0);
             oaiRecords.add(oaiRecord);
 
+            //TODO: we ave to check all the parts name and assigned according to related name not order
             String[] parts = parsedDc.getDc().split(";;");
             Article article = new Article();
-//            System.out.println("article create sonrasi article id : "+article.getId());
-//            System.out.println("article create sonrasi oai id : "+oaiRecord.getId());
-
             article.setTitle(parts[0].split("::")[1]);
             article.setAuthors(parts[1].split("::")[1]);
             article.setKeywords(parts[2].split("::")[1]);
@@ -195,23 +156,18 @@ public class OaiService {
             {
                 String downlaodUrl = parts[10].split("::")[1];
                 article.setRelation(downlaodUrl);
-//                article.setBase64("not available");
                 article.setBase64(UrlPdftoBase64(downlaodUrl));
             }
             else
             {
                 article.setRelation("not available");
-                article.setBase64("bm90IGF2YWlsYWJsZQ==");
+                article.setBase64("bm90IGF2YWlsYWJsZQ=="); //it means not available in base 64
             }
             article.setDc(parsedDc.getDc());
             article.setArticleIdentifier(parseIdentifier(oaiRecord.getIdentifier()));
-//            article.setArticleIdentifier(oaiRecord.getIdentifier());
 
-//            System.out.println("article add oncesi article id : "+article.getId());
             articles.add(article);
 
-//            System.out.println("elastic save oncesi article id : "+article.getId());
-//            System.out.println("elastic save oncesi article title : "+article.getTitle());
             try {
                 elasticSave(article);
             } catch (IOException e) {
@@ -247,13 +203,8 @@ public class OaiService {
         try {
             oracle = new URL(url);
             URLConnection yc = oracle.openConnection();
-//            BufferedReader in = new BufferedReader(new InputStreamReader(
-//                    yc.getInputStream()));
+
             BufferedInputStream bis = new BufferedInputStream(yc.getInputStream());
-//            String inputLine;
-//            while ((inputLine = in.readLine()) != null)
-//                System.out.println(inputLine);
-//            in.close();
 
             byte bytes[] = IOUtils.toByteArray(bis);
             bis.close();
@@ -266,30 +217,7 @@ public class OaiService {
             e.printStackTrace();
         }
 
-
-
-
         return base64;
-
-//            String inputLine;
-//            while ((inputLine = in.readLine()) != null)
-//                System.out.println(inputLine);
-//            in.close();
-
-
-
-
-//            BufferedReader in = new BufferedReader(
-//                    new InputStreamReader(oracle.openStream()));
-//            byte bytes[] = IOUtils.toByteArray(oracle);
-
-
-//            String b64String = Base64.
-
-//            String inputLine;
-//            while ((inputLine = in.readLine()) != null)
-//                System.out.println(inputLine);
-//            in.close();
 
     }
 

--- a/src/main/java/io/academic/service/OaiService.java
+++ b/src/main/java/io/academic/service/OaiService.java
@@ -316,11 +316,19 @@ public class OaiService {
     }
 
 
-    public void delete() throws IOException {
+    public void delete() {
 
-        //TODO:check if there is any indices with that name
-        DeleteIndexRequest request = new DeleteIndexRequest("harvester");
-        restClient.indices().deleteIndex(request);
+        try {
+            DeleteIndexRequest request = new DeleteIndexRequest("harvester");
+            restClient.indices().deleteIndex(request);
+        } catch (ElasticsearchException exception) {
+            if (exception.status() == RestStatus.NOT_FOUND) {
+                System.out.println("Index not found and not deleted");
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
 
     }
 

--- a/src/main/java/io/academic/service/ProcessorService.java
+++ b/src/main/java/io/academic/service/ProcessorService.java
@@ -37,11 +37,9 @@ public class ProcessorService {
 
         oaiDataProviderService.queue(new OaiDataProvider("Acta Medica Anatolia","http://dergipark.gov.tr/api/public/oai/","http://dergipark.gov.tr/download/article-file/","dergipark.ulakbim.gov.tr"  ));
 //        oaiDataProviderService.queue(new OaiDataProvider("http://export.arxiv.org/oai2","https://arxiv.org/pdf/"));
-        try {
+
             oaiService.delete();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+
 
     }
 

--- a/src/main/java/io/academic/service/ProcessorService.java
+++ b/src/main/java/io/academic/service/ProcessorService.java
@@ -38,8 +38,7 @@ public class ProcessorService {
         oaiDataProviderService.queue(new OaiDataProvider("Acta Medica Anatolia","http://dergipark.gov.tr/api/public/oai/","http://dergipark.gov.tr/download/article-file/","dergipark.ulakbim.gov.tr"  ));
 //        oaiDataProviderService.queue(new OaiDataProvider("http://export.arxiv.org/oai2","https://arxiv.org/pdf/"));
 
-            oaiService.delete();
-
+        oaiService.delete();
 
     }
 

--- a/src/main/java/io/academic/service/ProcessorService.java
+++ b/src/main/java/io/academic/service/ProcessorService.java
@@ -35,8 +35,8 @@ public class ProcessorService {
         taskExecutor.execute(recordTypeProcessor);
         taskExecutor.execute(urlProcessor);
 
-        oaiDataProviderService.queue(new OaiDataProvider("Acta Medica Anatolia","http://dergipark.gov.tr/api/public/oai/","dergipark.ulakbim.gov.tr"  ));
-//        oaiDataProviderService.queue(new OaiDataProvider("http://export.arxiv.org/oai2"));
+        oaiDataProviderService.queue(new OaiDataProvider("Acta Medica Anatolia","http://dergipark.gov.tr/api/public/oai/","http://dergipark.gov.tr/download/article-file","dergipark.ulakbim.gov.tr"  ));
+//        oaiDataProviderService.queue(new OaiDataProvider("http://export.arxiv.org/oai2","https://arxiv.org/pdf/"));
         try {
             oaiService.delete();
         } catch (IOException e) {

--- a/src/main/java/io/academic/service/ProcessorService.java
+++ b/src/main/java/io/academic/service/ProcessorService.java
@@ -35,7 +35,7 @@ public class ProcessorService {
         taskExecutor.execute(recordTypeProcessor);
         taskExecutor.execute(urlProcessor);
 
-        oaiDataProviderService.queue(new OaiDataProvider("Acta Medica Anatolia","http://dergipark.gov.tr/api/public/oai/","http://dergipark.gov.tr/download/article-file","dergipark.ulakbim.gov.tr"  ));
+        oaiDataProviderService.queue(new OaiDataProvider("Acta Medica Anatolia","http://dergipark.gov.tr/api/public/oai/","http://dergipark.gov.tr/download/article-file/","dergipark.ulakbim.gov.tr"  ));
 //        oaiDataProviderService.queue(new OaiDataProvider("http://export.arxiv.org/oai2","https://arxiv.org/pdf/"));
         try {
             oaiService.delete();


### PR DESCRIPTION
Documents (pdf) taken as inputstream and converted to base64 and added to elasticsearch in pipeline attachment and base64 part removed and content left on elasticsearch.

Before using harvester following pipeline attachment needs to add to elasticsearch
PUT _ingest/pipeline/academic-pdf
{
  "description": "parse pdfs and index into ES",
  "processors" :
    [
      { "attachment" : { "field": "pdf" } },
      { "remove" : { "field": "pdf" } }
    ]
}

ps:docx version is not tested yet but in theory this kind of approach should work in every type of files